### PR TITLE
chore: ensures visibility in the Astro integrations library

### DIFF
--- a/.changeset/curvy-radios-pump.md
+++ b/.changeset/curvy-radios-pump.md
@@ -1,0 +1,8 @@
+---
+"@ascorbic/airtable-loader": patch
+"@ascorbic/feed-loader": patch
+"@ascorbic/mock-loader": patch
+"@ascorbic/csv-loader": patch
+---
+
+Ensures loader visibility in the [Astro integrations library](https://astro.build/integrations/?search=&categories%5B%5D=loaders).

--- a/packages/airtable/package.json
+++ b/packages/airtable/package.json
@@ -28,7 +28,7 @@
 		"astro": "^4.14.0 || ^5.0.0-beta.0"
 	},
 	"keywords": [
-		"astro",
+		"withastro",
 		"astro-loader"
 	],
 	"author": "",

--- a/packages/csv/package.json
+++ b/packages/csv/package.json
@@ -29,7 +29,7 @@
 		"astro": "^4.15.0"
 	},
 	"keywords": [
-		"astro",
+		"withastro",
 		"astro-loader"
 	],
 	"author": "",

--- a/packages/feed/package.json
+++ b/packages/feed/package.json
@@ -29,7 +29,7 @@
 		"astro": "^4.14.0 || ^5.0.0-beta.0"
 	},
 	"keywords": [
-		"astro",
+		"withastro",
 		"astro-loader"
 	],
 	"author": "",

--- a/packages/mock/package.json
+++ b/packages/mock/package.json
@@ -28,7 +28,7 @@
 		"astro": "^4.14.0 || ^5.0.0-beta.0"
 	},
 	"keywords": [
-		"astro",
+		"withastro",
 		"astro-loader"
 	],
 	"author": "",


### PR DESCRIPTION
#### Description

At the moment, all the loaders are not listed in the [Astro integrations library](https://astro.build/integrations/?search=&categories%5B%5D=loaders). To be listed, on top of the Content Loaders (`astro-loader`) category keyword which is already used, a package must use one of the two [required](https://docs.astro.build/en/reference/publish-to-npm/#categories) `astro-component` or `withastro` keyword.

This PR replaces the `astro` keyword with the `withastro` keyword in the `package.json` file of the loaders so that they can be picked up by the Astro integrations library.

If this was done on purpose, feel free to disregard this PR.