### PR TITLE
fix: use built-in validations for Bluesky posts

### DIFF
--- a/.changeset/funny-deers-tap.md
+++ b/.changeset/funny-deers-tap.md
@@ -1,0 +1,5 @@
+---
+"@ascorbic/bluesky-loader": patch
+---
+
+use built-in validations for Bluesky posts

--- a/packages/bluesky/src/index.ts
+++ b/packages/bluesky/src/index.ts
@@ -1,9 +1,7 @@
 import { AtpAgent, type AppBskyFeedGetAuthorFeed } from "@atproto/api";
 import type { Loader } from "astro/loaders";
+import { PostViewSchema } from "./schema.js";
 import { renderPostAsHtml } from "./utils.js";
-import { PostSchema } from "./schema.js";
-export type { Post } from "./schema.js";
-export { renderPostAsHtml } from "./utils.js";
 
 /**
  * Load posts from a Bluesky author feed.
@@ -20,7 +18,7 @@ export const authorFeedLoader = ({
 }): Loader => {
   return {
     name: "bluesky-loader",
-    schema: PostSchema,
+    schema: PostViewSchema,
     async load({ store, logger, meta, parseData }) {
       const agent = new AtpAgent({ service: "https://public.api.bsky.app" });
       try {

--- a/packages/bluesky/src/schema.ts
+++ b/packages/bluesky/src/schema.ts
@@ -1,197 +1,32 @@
+import { AppBskyFeedDefs, AppBskyFeedPost } from "@atproto/api";
 import { z } from "astro/zod";
 
-// Internal Embed Types (non-#view)
-const EmbedExternalSchema = z.object({
-  $type: z.literal("app.bsky.embed.external"),
-  external: z.object({
-    description: z.string().optional(),
-    thumb: z
-      .object({
-        $type: z.literal("blob"),
-        ref: z.object({ $link: z.string() }),
-        mimeType: z.string(),
-        size: z.number(),
-      })
-      .optional(),
-    title: z.string().optional(),
-    uri: z.string().url(),
-  }),
-});
+export interface PostView extends AppBskyFeedDefs.PostView {
+  // `PostView` currently types `record` as `unknown` as a way to encourage
+  // clients to validate this themselves, we'll be checking for this.
+  record: AppBskyFeedPost.Record;
+}
 
-const EmbedRecordSchema = z.object({
-  $type: z.literal("app.bsky.embed.record"),
-  record: z.object({
-    uri: z.string(),
-    cid: z.string(),
-  }),
-});
+export const PostViewSchema = z
+  .unknown()
+  .superRefine((view: any, ctx): view is PostView => {
+    const viewResult = AppBskyFeedDefs.validatePostView(view);
+    if (!viewResult.success) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `Error validating view: ${viewResult.error.message}`,
+      });
 
-const EmbedRecordWithMediaSchema = z.object({
-  $type: z.literal("app.bsky.embed.recordWithMedia"),
-  media: EmbedExternalSchema,
-  record: EmbedRecordSchema,
-});
+      return z.NEVER;
+    }
 
-const EmbedImagesSchema = z.object({
-  $type: z.literal("app.bsky.embed.images"),
-  images: z.array(
-    z.object({
-      alt: z.string(),
-      aspectRatio: z.object({
-        height: z.number(),
-        width: z.number(),
-      }),
-      image: z.object({
-        $type: z.literal("blob"),
-        ref: z.object({ $link: z.string() }),
-        mimeType: z.string(),
-        size: z.number(),
-      }),
-    }),
-  ),
-});
+    const recordResult = AppBskyFeedPost.validateRecord(view.record);
+    if (!recordResult.success) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `Error validating record: ${recordResult.error.message}`,
+      });
+    }
 
-// #view Embed Types
-const EmbedExternalViewSchema = z.object({
-  $type: z.literal("app.bsky.embed.external#view"),
-  external: z.object({
-    uri: z.string().url(),
-    title: z.string().optional(),
-    description: z.string().optional(),
-    thumb: z.string().url().optional(), // Direct URL for view
-  }),
-});
-
-const EmbedRecordWithMediaViewSchema = z.object({
-  $type: z.literal("app.bsky.embed.recordWithMedia#view"),
-  media: EmbedExternalViewSchema,
-  record: z.object({
-    record: z.object({
-      $type: z.literal("app.bsky.embed.record#viewRecord"),
-      uri: z.string(),
-      cid: z.string(),
-      author: z.object({
-        did: z.string(),
-        handle: z.string(),
-        displayName: z.string(),
-        avatar: z.string().url().optional(),
-      }),
-      value: z.object({
-        $type: z.literal("app.bsky.feed.post"),
-        createdAt: z.string().datetime(),
-      }),
-    }),
-  }),
-});
-
-const EmbedImagesViewSchema = z.object({
-  $type: z.literal("app.bsky.embed.images#view"),
-  images: z.array(
-    z.object({
-      thumb: z.string().url(),
-      fullsize: z.string().url(),
-      alt: z.string().optional(),
-      aspectRatio: z
-        .object({
-          height: z.number(),
-          width: z.number(),
-        })
-        .optional(),
-    }),
-  ),
-});
-
-// Main Post Schema
-export const PostSchema = z.object({
-  uri: z.string(),
-  cid: z.string(),
-  author: z.object({
-    did: z.string(),
-    handle: z.string(),
-    displayName: z.string(),
-    avatar: z.string().url().optional(),
-    associated: z
-      .object({
-        chat: z
-          .object({
-            allowIncoming: z.enum(["following", "all", "none"]).optional(),
-          })
-          .optional(),
-      })
-      .optional(),
-    labels: z.array(z.any()).optional(),
-    createdAt: z.string().datetime(),
-  }),
-  record: z.object({
-    $type: z.literal("app.bsky.feed.post"),
-    createdAt: z.string().datetime(),
-    langs: z.array(z.string()),
-    text: z.string().max(3000),
-    reply: z
-      .object({
-        parent: z.object({
-          cid: z.string(),
-          uri: z.string(),
-        }),
-        root: z.object({
-          cid: z.string(),
-          uri: z.string(),
-        }),
-      })
-      .optional(),
-    embed: z
-      .union([
-        EmbedExternalSchema,
-        EmbedRecordSchema,
-        EmbedRecordWithMediaSchema,
-        EmbedImagesSchema,
-      ])
-      .optional(),
-    facets: z
-      .array(
-        z.object({
-          index: z.object({
-            byteStart: z.number().nonnegative(),
-            byteEnd: z.number().nonnegative(),
-          }),
-          features: z.array(
-            z.union([
-              z.object({
-                $type: z.literal("app.bsky.richtext.facet#mention"),
-                did: z.string(),
-              }),
-              z.object({
-                $type: z.literal("app.bsky.richtext.facet#link"),
-                uri: z.string().url(),
-              }),
-              z.object({
-                $type: z.literal("app.bsky.richtext.facet#tag"),
-                tag: z.string(),
-              }),
-              z.object({
-                // Unknown facet type
-                $type: z.string(),
-                tag: z.string(),
-              }),
-            ]),
-          ),
-        }),
-      )
-      .optional(),
-  }),
-  embed: z
-    .union([
-      EmbedExternalViewSchema,
-      EmbedRecordWithMediaViewSchema,
-      EmbedImagesViewSchema,
-    ])
-    .optional(), // Embed at top level as a single object
-  replyCount: z.number().nonnegative(),
-  repostCount: z.number().nonnegative(),
-  likeCount: z.number().nonnegative(),
-  quoteCount: z.number().nonnegative(),
-  indexedAt: z.string().datetime(),
-  labels: z.array(z.any()).optional(),
-});
-
-export type Post = z.infer<typeof PostSchema>;
+    return z.NEVER;
+  });


### PR DESCRIPTION
Right now I have an issue where my posts doesn't validate properly because it makes use of custom lexicons.

AT Protocol's lexicons are designed to be open, and union types reflect this by being open by default, the intended behavior is for validations to ignore these rather than returning an error.

This also means that there is no longer a need to manually maintain a Zod schema for every time there's changes to the post record. Records in AT Protocol is practically mandated to be backwards-compatible.

<details>
<summary>Example post that fails the existing validation</summary>

This fails because of `blue.moji.richtext.facet`

```json
{
  "uri": "at://did:plc:ia76kvnndjutgedggx2ibrem/app.bsky.feed.post/3la5i7eeizcgu",
  "author": {
    "did": "did:plc:ia76kvnndjutgedggx2ibrem",
    "handle": "mary.my.id",
    "displayName": "mary🐇",
    "avatar": "https://cdn.bsky.app/img/avatar/plain/did:plc:ia76kvnndjutgedggx2ibrem/bafkreiesgyo7ukzqhs5mmtulvovzrbbru7ztvopwdwfsvllu553qgfmxd4@jpeg",
    "associated": {
      "chat": {
        "allowIncoming": "following"
      }
    },
    "viewer": {
      "muted": false,
      "blockedBy": false
    },
    "labels": [],
    "createdAt": "2023-10-14T22:32:58.570Z"
  },
  "record": {
    "$type": "app.bsky.feed.post",
    "createdAt": "2024-11-04T19:46:32.321Z",
    "facets": [
      {
        "features": [
          {
            "$type": "blue.moji.richtext.facet",
            "did": "did:plc:ia76kvnndjutgedggx2ibrem",
            "formats": {
              "$type": "blue.moji.richtext.facet#formats_v0",
              "png_128": "bafkreif32i7xs4ltlattqepkodgsqt5o7j44bfwdigjdz3u7vrgim4xwwm",
              "webp_128": "bafkreichujvpqyapxnke5uj7mc7p6k5kqprtxbfssstoj6xjh36kcetjoe"
            },
            "name": "◌"
          },
          {
            "$type": "app.bsky.richtext.facet#link",
            "uri": "https://github.com/aendra-rininsland/bluemoji"
          }
        ],
        "index": {
          "byteEnd": 3,
          "byteStart": 0
        }
      }
    ],
    "langs": [
      "en"
    ],
    "text": "◌"
  },
  "replyCount": 0,
  "repostCount": 0,
  "likeCount": 0,
  "quoteCount": 0,
  "indexedAt": "2024-11-04T19:46:32.321Z",
  "viewer": {
    "threadMuted": false,
    "replyDisabled": false,
    "embeddingDisabled": false,
    "pinned": false
  },
  "labels": [],
  "threadgate": {
    "uri": "at://did:plc:ia76kvnndjutgedggx2ibrem/app.bsky.feed.threadgate/3la5i7eeizcgu",
    "cid": "bafyreif3swvwrl6ydbs3g3lte443cnnbhtciny36wpirphrluxpkgpgwqi",
    "record": {
      "$type": "app.bsky.feed.threadgate",
      "allow": [
        {
          "$type": "app.bsky.feed.threadgate#followingRule"
        }
      ],
      "createdAt": "2024-11-04T19:46:32.321Z",
      "post": "at://did:plc:ia76kvnndjutgedggx2ibrem/app.bsky.feed.post/3la5i7eeizcgu"
    },
    "lists": []
  }
}
```

</details>
