### PR TITLE
docs: fix astro loader utils installation instruction

### DIFF
--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -5,7 +5,7 @@ Utilities to help building Astro loaders
 ## Installation
 
 ```sh
-npm install @ascorbic/feed-utils astro@experimental--contentlayer
+npm install @ascorbic/loader-utils
 ```
 
 ## API


### PR DESCRIPTION
This PR updates the `README.md` file for the Astro loader utils and specifically the installation command:

- Fix the package name: `@ascorbic/feed-utils` → `@ascorbic/loader-utils`
- Removes the `astro@experimental--contentlayer` experimental release (I think it's fine at this point?)